### PR TITLE
Fix ns requires - misplaced bracket!

### DIFF
--- a/test/silliness/core_test.cljs
+++ b/test/silliness/core_test.cljs
@@ -1,6 +1,6 @@
-(ns silliness.core-test)
-(:require [cljs.test :refer-macros [async deftest testing is]]
-          [silliness.core :refer [silly]])
+(ns silliness.core-test
+  (:require [cljs.test :refer-macros [async deftest testing is]]
+            [silliness.core :refer [silly]]))
 
 (deftest silly-test
   (is (= (silly)


### PR DESCRIPTION
Lispy grouping woes - the warnings you were seeing where the symbols you require being read as actual variables :smile: 

Also note your last few commits came through as a different username - if you're wanting to be pseudonymous perhaps you'll want to remove those commit from Github :worried: 